### PR TITLE
Add missing function toRootLowerCase

### DIFF
--- a/akka-actor/src/main/scala/akka/util/Helpers.scala
+++ b/akka-actor/src/main/scala/akka/util/Helpers.scala
@@ -14,6 +14,8 @@ import java.util.Locale
 
 object Helpers {
 
+  def toRootLowerCase(s: String) = s.toLowerCase(Locale.ROOT)
+  
   val isWindows: Boolean = System.getProperty("os.name", "").toLowerCase(Locale.ROOT).indexOf("win") >= 0
 
   def makePattern(s: String): Pattern = Pattern.compile("^\\Q" + s.replace("?", "\\E.\\Q").replace("*", "\\E.*\\Q") + "\\E$")


### PR DESCRIPTION
akka-streams depends on akka-actor, and this snowflake `akka-actors` distro has bunch of stuff missing :(
So you can't use anything that relies on streams or actors and was written in the past year. The struggle is real.

`java.lang.NoSuchMethodError: akka.util.Helpers$.toRootLowerCase(Ljava/lang/String;)Ljava/lang/String;
	at akka.stream.StreamSubscriptionTimeoutSettings$.apply(ActorMaterializer.scala:507)
	at akka.stream.ActorMaterializerSettings$.apply(ActorMaterializer.scala:259)
	at akka.stream.ActorMaterializerSettings$.apply(ActorMaterializer.scala:248)
	at akka.stream.ActorMaterializer$$anonfun$1.apply(ActorMaterializer.scala:41)
	at akka.stream.ActorMaterializer$$anonfun$1.apply(ActorMaterializer.scala:41)
	at scala.Option.getOrElse(Option.scala:121)
	at akka.stream.ActorMaterializer$.apply(ActorMaterializer.scala:41)`